### PR TITLE
Add buildpack for cleaning up the deployed slug

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,4 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git#ebc8094e11638f900f248c84bbf304c00dd30d6b
 https://github.com/mars/create-react-app-inner-buildpack.git#cb0c9d2fdefaa50eb294a6a0999d5ab3f0b83271
 https://github.com/heroku/heroku-buildpack-static.git#bde9522300fe5f1eb7513e7f2ee6731958987c23
+https://github.com/ekilah/heroku-buildpack-post-build-clean.git#48a468eb46b5ff6f458f3445ac38f699e19bcf43


### PR DESCRIPTION
Heroku currently copies our entire repo from `git`, builds the production app, and then copies the entire directory (including the consumed source files etc) to the machine(s) serving the app.

We don't need most of that stuff in there, and now (mostly since `node_modules` has gotten quite large, but also other things, like our source images/svgs are there twice) it has gotten big enough (>300MB) that Heroku is starting to warn us about the size.

`heroku-buildpack-post-build-clean` takes a `.slug-post-clean` file and deletes things you don't need in there after the build process. [My fork](https://github.com/ekilah/heroku-buildpack-post-build-clean/commit/48a468eb46b5ff6f458f3445ac38f699e19bcf43) gets rid of some errors because comments in the file weren't being ignored previously.